### PR TITLE
Ability to bypass CSS style from shortcode display

### DIFF
--- a/classes/Shortcodes.php
+++ b/classes/Shortcodes.php
@@ -25,7 +25,9 @@ class Shortcodes {
 	 * @param array $atts
 	 */
 	public function bhs_record_shortcode( $atts ) {
-		wp_enqueue_style( 'bhs-client', plugins_url() . '/bhs-client/assets/css/client.css' );
+		if(!isset($atts['styles']) || $atts['styles'] === 'true'){
+			wp_enqueue_style( 'bhs-client', plugins_url() . '/bhs-client/assets/css/client.css' );
+		}
 
 		$markup = '';
 


### PR DESCRIPTION
If the markup remains the same, but a theme stylesheet could be used for display, I think there'd be more flexibility in how the shortcode is used. I'm open to suggestions though, if there's a better way to strip out styles.